### PR TITLE
Return self when setting array param

### DIFF
--- a/lib/mssqlconnector.js
+++ b/lib/mssqlconnector.js
@@ -146,7 +146,7 @@
       }
       if (_isArray(value)) {
         this._addINStatement(field, datatype, value);
-        return;
+        return this;
       }
       if (!this._checkField(field, datatype)) {
         this._handleError(null, "param-not-found", "Param '" + field + "' was not found in query or is tried to set twice");


### PR DESCRIPTION
When setting an array parameter, `this` is not returned. This is not expected behaviour, and this PR fixes that.